### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Keyboard.observe().willShow
 
 ## Installation
 
-SignalKit requires Swift 2.0 and XCode 7
+SignalKit requires Swift 2.0 and Xcode 7
 
 #### Carthage
 Add the following line to your [Cartfile](https://github.com/carthage/carthage)


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
